### PR TITLE
[IRON-16691] Fix lack of group id

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
                 isMinifyEnabled = false
                 isDebuggable = true
                 manifestPlaceholders = mapOf("enableCrashReporting" to "true")
-                buildConfigField("String", "PS_BASE_URL", "\"https://dev.pactsafe.io\"")
+                buildConfigField("String", "PS_BASE_URL", "\"https://pactsafe.io\"")
             }
         }
 

--- a/app/src/main/java/com/pactsafe/pactsafeandroidsdk/data/ActivityServiceImp.kt
+++ b/app/src/main/java/com/pactsafe/pactsafeandroidsdk/data/ActivityServiceImp.kt
@@ -33,7 +33,7 @@ class ActivityServiceImp(private val activityAPI: ActivityAPI) :
                 "sig" to signer.signerId,
                 "et" to et,
                 "cus" to signer.customData.toString(),
-                "gid" to group?.id.toString(),
+                "gid" to group?.group.toString(),
                 "cnf" to group?.confirmation_email.toString(),
                 "tm" to false.toString(),
                 "sid" to applicationPreferences.siteAccessId

--- a/app/src/main/java/com/pactsafe/pactsafeandroidsdk/models/PSGroup.kt
+++ b/app/src/main/java/com/pactsafe/pactsafeandroidsdk/models/PSGroup.kt
@@ -18,7 +18,7 @@ data class PSGroup(
     // Group Key
     val key: String,
     // Group ID
-    val id: Int,
+    val group: Int,
     // Contract IDs that are part of the group
     val contracts: List<Int>,
     // Contract Version IDs that are part of the group.


### PR DESCRIPTION
# IRON-16691

## Description
We incorrectly were using `id` on the `PSGroup` object when it needed to be `group`. This will allow acceptances to be tied to a group and viewable in the new UI.

## Screen Recording
https://user-images.githubusercontent.com/4472810/211113110-86094023-df5e-4991-b998-3bc8af3f2b76.mov

## Testing

### Local Testing
When sending an acceptance using the Android Demo app, you should now see the acceptance in the app be tied to a group.

