### PR TITLE
Fixes to GitHub Publish Action

### DIFF
--- a/.github/workflows/package_publish.yml
+++ b/.github/workflows/package_publish.yml
@@ -11,7 +11,7 @@ jobs:
       BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
       GITHUB_RUN_ID: ${{ github.run_id }}
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -20,7 +20,7 @@ jobs:
 
     - name: Publish Package
       run: ./gradlew publish
-    
+
     - name: Read Properties
       id: read_property
       uses: christian-draeger/read-properties@1.0.1
@@ -46,18 +46,14 @@ jobs:
       with:
         tag_name: ${{ steps.read_property.outputs.value }}
         release_name: Release ${{ steps.read_property.outputs.value }}
-        body: |
-          Changes in this Release
-          - First Change
-          - Second Change
         draft: false
-        prerelease: falsel
-    
+        prerelease: false
+
     - name: Increment Version Revision
       run: ./gradlew incrementRevision
-      
+
     - name: Commit changes
       run: git commit -am "[skip ci] version revision bump"
-        
+
     - name: Push Changes
       run: git push

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,9 +15,7 @@ var versionProps = Properties()
 
 FileInputStream(versionFile).use { stream -> versionProps.load(stream) }
 val versionNumber = versionProps["version"].toString()
-
-val envBuildNumber = (System.getenv("GITHUB_RUN_ID") ?: "0").toBigInteger()
-
+val envBuildNumber = versionProps["version_code"] as? Int ?: 0
 
 android {
     compileSdkVersion(Android.compileSdkVersion)

--- a/app/versioning.gradle.kts
+++ b/app/versioning.gradle.kts
@@ -54,7 +54,6 @@ fun incrementMinorVersion() {
     }
 
     println("Major Version has been updated to: ${version["version"]}")
-
 }
 
 fun incrementRevisionVersion() {
@@ -64,9 +63,12 @@ fun incrementRevisionVersion() {
     var revision = version.getProperty("revision").toInt()
     revision++
 
+    var versionCode = version.getProperty("version_code").toInt()
+    versionCode++
+    version.setProperty("version_code", versionCode.toString())
+
     version.setProperty("revision", revision.toString())
     version.setProperty("version", "${version["major"] ?: 0}.${version["minor"] ?: 0}.${version["revision"] ?: 0}")
-
 
     FileOutputStream(versionFile).use { stream ->
         version.store(stream, null)

--- a/version.properties
+++ b/version.properties
@@ -3,3 +3,4 @@ major=0
 minor=1
 version=0.1.5
 revision=5
+version_code=1071787282


### PR DESCRIPTION
# Fix GitHub Publish Package Action

Previous PR did not correctly address the publish action. This cleans up the action and also addresses the issue of `versionCode` not being applied correctly.

The `versionCode` is now stored within `version.properties` with the last successful build number that was applied. This will allow us to increment by 1 rather than potentially running into issues of exceeding the max integer of Integer in the future.